### PR TITLE
fix: parameters are not available on uses context

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,14 +15,6 @@ on:
         default: "--all --check"
         required: true
         type: string
-      fmt-version:
-        default: stable
-        required: false
-        type: string
-      checkout-version:
-        default: v4
-        required: false
-        type: string
 
 jobs:
   check-fmt:
@@ -30,9 +22,9 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@${{ inputs.checkout-version }}
+        uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@${{ inputs.fmt-version }}
+      - uses: dtolnay/rust-toolchain@stable
       - name: checks
         run: |
           cargo fmt ${{ inputs.command }}


### PR DESCRIPTION
It seems like `uses` is not allowed to receive parameters

Info about it can be found here: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability